### PR TITLE
arm: kernel: utilize hrtimer based broadcast

### DIFF
--- a/arch/arm/kernel/time.c
+++ b/arch/arm/kernel/time.c
@@ -12,6 +12,7 @@
  *  reading the RTC at bootup, etc...
  */
 #include <linux/clk-provider.h>
+#include <linux/clockchips.h>
 #include <linux/clocksource.h>
 #include <linux/errno.h>
 #include <linux/export.h>
@@ -121,5 +122,7 @@ void __init time_init(void)
 		of_clk_init(NULL);
 #endif
 		clocksource_probe();
+
+		tick_setup_hrtimer_broadcast();
 	}
 }


### PR DESCRIPTION
Hrtimer based broadcast is used on ARM platform. It can be registered as the tick broadcast device in the absence of a real external clock device.